### PR TITLE
Remove content-encoding, which prevents oss serving gzip version.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ function uploadOss(bucket, release, content, file,callback) {
     ContentType: contenttype,
     CacheControl: 'cache',         // 参考: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
     ContentDisposition: '',           // 参考: http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1
-    ContentEncoding: 'utf-8',         // 参考: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
     ServerSideEncryption: '',
     Expires: 60
   },function (err, data) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function uploadOss(bucket, release, content, file,callback) {
     ContentDisposition: '',           // 参考: http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1
     ContentEncoding: 'utf-8',         // 参考: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11
     ServerSideEncryption: '',
-    Expires: 60
+    Expires: new Date().getTime() + 1000*24*60*60*1000
   },function (err, data) {
       if(err){
         console.log('error:', err);


### PR DESCRIPTION
因为上传的时候显示指定了`content-encoding`的值，会导致oss不接受`Accept-Encoding:gzip` header，不会返回gzip后的js/css文件。
